### PR TITLE
Emit pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.4
+
+-   Create script uses emit pattern
+
 ## 0.1.3
 
 -   Bumps dependency versions

--- a/bin/create_page.dart
+++ b/bin/create_page.dart
@@ -67,9 +67,9 @@ import '${name}_events.dart';
 export '${name}_events.dart';
 
 class $nameCapitalized extends StateView<${nameCapitalized}State> {
-  $nameCapitalized({Key? key})
-      : super(
-          key: key,
+  $nameCapitalized({
+    super.key,
+  }) : super(
           stateBuilder: (context) => ${nameCapitalized}State(context),
           view: ${nameCapitalized}View(),
         );
@@ -100,7 +100,7 @@ import 'package:provider/provider.dart';
 import '${name}_state.dart';
 
 class ${nameCapitalized}View extends StatelessWidget {
-  const ${nameCapitalized}View({Key? key}) : super(key: key);
+  const ${nameCapitalized}View({super.key});
   @override
   Widget build(BuildContext context) {
     final state = context.watch<${nameCapitalized}State>();

--- a/bin/create_page.dart
+++ b/bin/create_page.dart
@@ -60,8 +60,7 @@ extension StringCasingExtension on String {
 
 String createPageFile(String name) {
   String nameCapitalized = getPascalCaseFromSnakeCase(name);
-  return '''import 'package:flutter/material.dart';
-import 'package:state_view/state_view.dart';
+  return '''import 'package:state_view/state_view.dart';
 import '${name}_view.dart';
 import '${name}_events.dart';
 export '${name}_events.dart';
@@ -76,10 +75,12 @@ class $nameCapitalized extends StateView<${nameCapitalized}State> {
 }
 
 class ${nameCapitalized}State extends StateProvider<$nameCapitalized, ${nameCapitalized}Event> {
-  ${nameCapitalized}State(super.context);
-  @override
-  void onEvent(${nameCapitalized}Event event) {
-    return;
+  ${nameCapitalized}State(super.context) {
+    registerHandler<OnExampleTap>(_handleExampleTap);
+  }
+
+  void _handleExampleTap(OnExampleTap event) {
+    // TODO: handle example tap logic
   }
 }
 ''';

--- a/lib/src/state_view.dart
+++ b/lib/src/state_view.dart
@@ -23,10 +23,10 @@ class StateView<T extends StateProvider> extends StatefulWidget {
   final T Function(BuildContext) stateBuilder;
   final Widget view;
   StateView({
-    Key? key,
+    super.key,
     required this.stateBuilder,
     required this.view,
-  }) : super(key: key) {
+  }) {
     assert(
       T.toString() != 'StateProvider<StatefulWidget, dynamic>',
       'Must specify a type.  '

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: state_view
 description: Provides the state view pattern for Flutter, creating a strong separation between UI and domain logic.
 repository: https://github.com/ZacharyBohn/state-view-pattern
-version: 0.1.3
+version: 0.1.4
 
 environment:
     sdk: '>=2.18.4 <4.0.0'

--- a/test/test_examples.dart
+++ b/test/test_examples.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:state_view/state_view.dart';
 
-main() => runApp(
+void main() => runApp(
       MaterialApp(
         home: HomePage(initialUsername: 'test_username'),
       ),
@@ -13,17 +13,16 @@ main() => runApp(
 class HomePage extends StateView<HomeState> {
   final String initialUsername;
   HomePage({
-    Key? key,
+    super.key,
     required this.initialUsername,
   }) : super(
-          key: key,
           stateBuilder: (context) => HomeState(context),
           view: const HomeView(),
         );
 }
 
 class HomeState extends StateProvider<HomePage, HomeEvent> {
-  HomeState(BuildContext context) : super(context) {
+  HomeState(super.context) {
     _username = widget.initialUsername;
   }
 
@@ -70,9 +69,8 @@ class HomeView extends StatelessWidget {
 
 class SettingsPage extends StateView {
   SettingsPage({
-    Key? key,
+    super.key,
   }) : super(
-          key: key,
           stateBuilder: (context) => HomeState(context),
           view: Container(),
         );
@@ -122,9 +120,8 @@ class DependenciesChangeExampleButton extends StatelessWidget {
 class DependenciesChangedExample
     extends StateView<DependenciesChangedExampleState> {
   final String value;
-  DependenciesChangedExample({Key? key, required this.value})
+  DependenciesChangedExample({super.key, required this.value})
       : super(
-          key: key,
           stateBuilder: (context) => DependenciesChangedExampleState(context),
           view: const DependenciesChangedExampleView(),
         );


### PR DESCRIPTION
# Goals

- Switches the create script to use the emit pattern, rather than the onEvent pattern.
- The emit pattern reduces the risk that developers will add non-event routing logic to the onEvent function.